### PR TITLE
Make retired-artifact smoke portable to Bash 3

### DIFF
--- a/tools/web/deploy/vps/deploy.sh
+++ b/tools/web/deploy/vps/deploy.sh
@@ -1166,14 +1166,10 @@ retired_public_asset_index=0
 for retired_public_asset_path in "${retired_public_asset_paths[@]}"; do
     for retired_public_asset_method in "${retired_public_asset_methods[@]}"; do
         retired_public_asset_headers="${smoke_root}/retired-public-asset-${retired_public_asset_index}-${retired_public_asset_method}.headers"
-        retired_public_asset_curl_mode=()
-        if [[ "${retired_public_asset_method}" == HEAD ]]; then
-            retired_public_asset_curl_mode=( --head )
-        fi
         retired_public_asset_status=$(
             curl --silent --show-error --max-time 30 \
                 --location --max-redirs 0 --proto '=https' \
-                "${retired_public_asset_curl_mode[@]}" \
+                --request "${retired_public_asset_method}" \
                 --dump-header "${retired_public_asset_headers}" \
                 --output /dev/null \
                 --write-out '%{http_code}' \
@@ -1217,14 +1213,10 @@ firmware_not_found_index=0
 for firmware_not_found_path in "${firmware_not_found_paths[@]}"; do
     for firmware_not_found_method in "${firmware_not_found_methods[@]}"; do
         firmware_not_found_headers="${smoke_root}/firmware-not-found-${firmware_not_found_index}-${firmware_not_found_method}.headers"
-        firmware_not_found_curl_mode=()
-        if [[ "${firmware_not_found_method}" == HEAD ]]; then
-            firmware_not_found_curl_mode=( --head )
-        fi
         firmware_not_found_status=$(
             curl --silent --show-error --max-time 30 \
                 --location --max-redirs 0 --proto '=https' \
-                "${firmware_not_found_curl_mode[@]}" \
+                --request "${firmware_not_found_method}" \
                 --dump-header "${firmware_not_found_headers}" \
                 --output /dev/null \
                 --write-out '%{http_code}' \

--- a/tools/web/src/test/vps-deployment-contract.test.ts
+++ b/tools/web/src/test/vps-deployment-contract.test.ts
@@ -119,6 +119,10 @@ describe("Cloudflare-fronted VPS deployment", () => {
     expect(script).toContain("/social/pyble-beta-og-1200x630.png");
     expect(script).toContain("/social/pyble-beta-og-1200x630.svg");
     expect(script).toContain("retired_public_asset_methods=( GET HEAD )");
+    expect(script).toContain(
+      '--request "${retired_public_asset_method}"',
+    );
+    expect(script).not.toContain("retired_public_asset_curl_mode");
     expect(script).toMatch(/retired_public_asset_status[\s\S]*?!= 404/);
     expect(script).toContain("Cache-Control: *no-store");
   });
@@ -468,6 +472,12 @@ describe("Cloudflare-fronted VPS deployment", () => {
     );
     expect(firmwareNotFoundSmoke).toContain(
       "firmware_not_found_methods=( GET HEAD )",
+    );
+    expect(firmwareNotFoundSmoke).toContain(
+      '--request "${firmware_not_found_method}"',
+    );
+    expect(firmwareNotFoundSmoke).not.toContain(
+      "firmware_not_found_curl_mode",
     );
     expect(firmwareNotFoundSmoke).toContain("esp32-c3-4mb/manifest.json");
     expect(firmwareNotFoundSmoke).toContain("--dump-header");

--- a/tools/web/src/test/vps-deployment-contract.test.ts
+++ b/tools/web/src/test/vps-deployment-contract.test.ts
@@ -119,9 +119,7 @@ describe("Cloudflare-fronted VPS deployment", () => {
     expect(script).toContain("/social/pyble-beta-og-1200x630.png");
     expect(script).toContain("/social/pyble-beta-og-1200x630.svg");
     expect(script).toContain("retired_public_asset_methods=( GET HEAD )");
-    expect(script).toContain(
-      '--request "${retired_public_asset_method}"',
-    );
+    expect(script).toContain('--request "${retired_public_asset_method}"');
     expect(script).not.toContain("retired_public_asset_curl_mode");
     expect(script).toMatch(/retired_public_asset_status[\s\S]*?!= 404/);
     expect(script).toContain("Cache-Control: *no-store");
@@ -476,9 +474,7 @@ describe("Cloudflare-fronted VPS deployment", () => {
     expect(firmwareNotFoundSmoke).toContain(
       '--request "${firmware_not_found_method}"',
     );
-    expect(firmwareNotFoundSmoke).not.toContain(
-      "firmware_not_found_curl_mode",
-    );
+    expect(firmwareNotFoundSmoke).not.toContain("firmware_not_found_curl_mode");
     expect(firmwareNotFoundSmoke).toContain("esp32-c3-4mb/manifest.json");
     expect(firmwareNotFoundSmoke).toContain("--dump-header");
     expect(firmwareNotFoundSmoke).toContain("--write-out '%{http_code}'");


### PR DESCRIPTION
## Summary

- reproduce the production deployment failure under macOS Bash 3 with a regression guard
- replace empty optional argument arrays with portable explicit `curl --request GET|HEAD`
- retain exact GET and HEAD 404/no-store verification for retired v0.4.1 firmware and unversioned social cards

## Incident behavior

The first deployment of protected-main commit `e56371384cfec28e12002a345ca8df0c0bbb5c5e` reached post-activation smoke, then macOS Bash 3 raised `retired_public_asset_curl_mode[@]: unbound variable`. The activation trap restored `/srv/pyble/releases/20260731T164104Z-88b649c03c8b`; the source marker, Nginx configuration, v0.4.2 bytes, and public installer remained healthy.

## Validation

- red regression: both retired-artifact contract checks fail against the array implementation
- green targeted deployment contract: **24 passed**
- complete website gate: formatting, lint, typecheck, license audit, **174 tests**, vinext compatibility, Next static build, and Sites build all pass
- `bash -n tools/web/deploy/vps/deploy.sh`: pass

No firmware bytes or release evidence changed.
