### PR TITLE
Add TestFlight build 4 test copy

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,11 @@ shared conformance corpus in one pull request.
 - [`validation/`](validation/) — retained release and hardware qualification
   evidence
 
+## Testing and release handoff
+
+- [PyBLE 0.1.0 (4) TestFlight description and test
+  plan](testing/testflight/0.1.0-build-4.md)
+
 Internal sprint notes and automated-agent orchestration are intentionally kept
 outside the public source repository. Public work is planned through the
 roadmap and GitHub issues.

--- a/docs/testing/testflight/0.1.0-build-4.md
+++ b/docs/testing/testflight/0.1.0-build-4.md
@@ -1,0 +1,142 @@
+# PyBLE 0.1.0 (4) TestFlight test description
+
+This document contains the English (`en-US`) TestFlight copy and test plan for
+PyBLE app version `0.1.0`, build `4`. It is written for external beta testers
+updating from TestFlight build `2`.
+
+- App bundle ID: `dev.pyble.pyble`
+- App source: `1d6d4fed9b98e12ae1c6bf159eb12a04ca0f8f2a`
+- Qualified board-agent release: `0.6.0`
+- TestFlight channel: public external beta
+
+Apple treats the Beta App Description as app-level information and What to Test
+as build-specific information. Paste only the text inside the corresponding
+plain-text blocks into App Store Connect. Keep tester or reviewer credentials
+out of both fields; PyBLE does not require an account or test credentials.
+
+## Beta App Description
+
+```text
+PyBLE is a free, open-source, tablet-first MicroPython IDE. It connects an iPad to a compatible board running the PyBLE agent over Bluetooth Low Energy, so you can edit, save, run, and stop MicroPython programs, view live console output, manage board files, and build programs with offline Blocks—without Wi-Fi onboarding or an account.
+
+Build 4 adds Python syntax highlighting, synchronized line numbers, adjustable editor text, connected board identity and firmware details, and an optional importer that lets you review public GitHub .py examples before downloading. GitHub import is the app's only Internet-dependent workflow. Imported code is never opened or run automatically.
+```
+
+## What to Test
+
+```text
+Build 4 adds three areas to TestFlight build 2:
+
+1. Connect to a compatible board running qualified PyBLE firmware v0.6.0. Confirm that the Ready/Running status pill shows the correct Board ID and PyBLE firmware version. Disconnect and reconnect—or switch boards—and confirm old identity values never remain.
+
+2. In Editor, confirm Python syntax colors and one-based line numbers stay aligned while typing and scrolling. Use the text-size controls through the full 10–24 range, rotate the iPad, and verify your code, cursor or selection, unsaved state, and Undo history remain intact. If available, also test Tab and indentation with an external keyboard.
+
+3. In Files, open or create a destination folder and choose “Import examples from GitHub.” Use https://github.com/PyBLE-dev/PyBLE with ref main, then browse to examples/github-import. Select hello.py or count.py, review the pinned commit and exact board paths, and confirm the download. Please also test the separate overwrite warning. Imported files must not open or run automatically.
+
+Please recheck scanning, connect and reconnect, Save, Run, Stop, console output, Files operations, portrait and landscape layouts, and offline Blocks for regressions.
+
+When reporting feedback, include the iPad model, iPadOS version, exact board profile, Board ID and PyBLE firmware shown, steps taken, and expected versus actual result. Screenshots or recordings are welcome when they contain no private code or credentials.
+```
+
+## Tester setup
+
+1. Back up the board before provisioning. Installing PyBLE firmware erases its
+   existing flash workspace.
+2. Install qualified firmware v0.6.0 from
+   [pyble.dev/flash](https://pyble.dev/flash), choosing only the exact profile
+   that matches the board and memory topology:
+   - `esp32-4mb`
+   - `esp32-s3-n16r8`
+   - `waveshare-esp32-s3-lcd-147b`
+   - `esp32-c3-4mb`
+   - `rpi-pico2-w`
+3. Provision an ESP profile from a supported desktop Chromium browser. For
+   Pico 2 W, use the verified UF2 download and copy it in BOOTSEL mode. iPadOS
+   cannot perform either wired provisioning workflow.
+4. Power the board, keep it nearby, and allow Bluetooth access when PyBLE asks.
+   Stock MicroPython without a conforming PyBLE agent will not appear as a
+   compatible PBLE/1 board.
+5. Internet access is needed only for the optional GitHub-import scenario. A
+   GitHub account or token is neither needed nor accepted.
+
+## Focused test matrix
+
+| Area | Exercise | Expected result |
+| --- | --- | --- |
+| Board identity | Connect, run, stop, disconnect, reconnect, and switch boards | The current Board ID and agent version appear in the Ready/Running pill; values from an earlier connection never leak into the new session. |
+| Editor gutter | Type, delete, paste multiline code, and scroll vertically | One-based line numbers remain visible and aligned with the corresponding code lines. Horizontal code scrolling does not move the gutter. |
+| Editor sizing | Change code size from 10 through 24 points, rotate, then Undo | Code and gutter resize together. The document, board path, dirty state, selection, and Undo history remain intact. Accessibility text scaling still composes with the editor setting. |
+| Editor input | Type straight quotes and, when available, use an external keyboard for Tab and Shift-Tab | Smart punctuation does not corrupt Python syntax. Literal tabs and selection indentation remain safe and predictable. |
+| GitHub browsing | Browse the canonical repository and inspect the resolved ref | The chosen ref resolves once to a visible immutable commit SHA. Browsing remains bounded and does not require a GitHub login. |
+| GitHub import | Review and import `hello.py` or `count.py` into the current Files folder | The review shows exact source and destination paths. Existing files require separate overwrite consent. The imported file does not open or run automatically. |
+| Core regression | Save, Run, Stop, observe console output, manage Files, and use offline Blocks in both orientations | Existing BLE-first workflows remain responsive and no account or network connection is required. |
+
+## Expected boundaries and known limitations
+
+- Editor font size is app-session state. Relaunching the app returns it to the
+  14-point default; persistence is intentionally deferred to the planned
+  settings store.
+- GitHub import accepts public repositories and selected ordinary lowercase
+  `.py` files from one displayed folder. It writes only to the current
+  connected board folder; it does not keep a durable local project copy or
+  provenance record, recreate nested folders, open the imported file, or run
+  it.
+- The complete selected batch is fetched and validated before board writes
+  begin. If a later write is cancelled or fails, successfully written earlier
+  files may remain; the result must distinguish succeeded, failed, and
+  unattempted files.
+- Editing, BLE, Files, Blocks, and Run remain offline and account-free. Public,
+  unauthenticated GitHub requests begin only after the tester opens the
+  importer.
+- PyBLE is capability-defined rather than restricted to one chip family, but a
+  board needs a maintained PBLE/1 agent, BLE GATT peripheral support, adequate
+  resources, and the project's conformance and hardware-validation gates.
+
+## Feedback checklist
+
+For actionable TestFlight feedback, include:
+
+- iPad model and exact iPadOS version;
+- PyBLE app version and build from About;
+- exact firmware profile used;
+- Board ID and PyBLE agent version shown by the app;
+- whether the issue followed first connect, reconnect, or a board switch;
+- numbered reproduction steps and expected versus actual behavior;
+- whether portrait/landscape, accessibility text scaling, or an external
+  keyboard was involved; and
+- a screenshot, screen recording, or TestFlight crash report when it contains
+  no private code, repository credentials, or other secrets.
+
+## App Store Connect handoff
+
+- Paste **Beta App Description** under TestFlight **Additional → Test
+  Information** for the English localization.
+- Paste **What to Test** into the English build localization for `0.1.0 (4)`.
+- Set the maintained feedback email separately; Apple requires it for external
+  testing.
+- Complete the separate **Beta App Review Information** with the maintained
+  reviewer's first name, last name, email address, and phone number. Mark a
+  demo account as not required because PyBLE has no sign-in. Put any physical
+  board access or setup guidance needed by the reviewer in the review-only
+  notes.
+- Confirm the live field counters before saving. Apple's current public
+  TestFlight documentation does not publish maximum lengths for these two
+  fields, so this document does not assert an unofficial limit.
+- Put any private review-only directions in TestFlight App Review Information,
+  never in tester-visible copy.
+
+Apple references:
+
+- [Provide test information](https://developer.apple.com/help/app-store-connect/test-a-beta-version/provide-test-information/)
+- [Include notes for testers](https://developer.apple.com/documentation/xcode/including-notes-for-testers-with-a-beta-release-of-your-app)
+- [Beta App Localization attributes](https://developer.apple.com/documentation/appstoreconnectapi/betaapplocalization/attributes-data.dictionary)
+- [Beta Build Localizations](https://developer.apple.com/documentation/appstoreconnectapi/beta-build-localizations)
+- [Beta App Review Detail](https://developer.apple.com/documentation/appstoreconnectapi/beta-app-review-detail)
+
+Project references:
+
+- [Changelog](../../../CHANGELOG.md)
+- [Current app capabilities](../../../app/README.md)
+- [Detailed app requirements](../../specifications/App/specs.md)
+- [Rich editor decision](../../decisions/0012-flutter-code-editor-behind-editorsurface.md)
+- [GitHub import decision](../../decisions/0040-sha-pinned-connected-github-import.md)


### PR DESCRIPTION
## Summary

- add paste-ready English Beta App Description and What to Test copy for PyBLE 0.1.0 (4)
- document the exact build-2-to-build-4 test focus, qualified-board setup, expected boundaries, feedback checklist, and App Store Connect handoff
- link the TestFlight document from the documentation index

## Validation

- 29 publication tests passed
- repository-local Markdown link gate passed
- no-leak gate passed
- git diff --check passed
- Beta App Description: 684 characters
- What to Test: 1,479 characters

No app behavior, version, signing material, or build artifact is changed.