### PR TITLE
[docs] Add project citation metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ Root governance files are:
 
 ```text
 README.md  LICENSE  CONTRIBUTING.md  CODE_OF_CONDUCT.md  SECURITY.md
-CHANGELOG.md  AGENTS.md  CLAUDE.md  .gitignore  .gitmodules
+CHANGELOG.md  CITATION.cff  AGENTS.md  CLAUDE.md  .gitignore  .gitmodules
 ```
 
 Put specifications and decisions under `docs/`, scripts under `tools/` or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ its annotated tag rather than from the newer branch tip.
 
 ### Website and repository source
 
+- Added project-level `CITATION.cff` metadata for scholarly citation while
+  preserving the independently versioned app and firmware release identities.
 - Established `PyBLE-dev/PyBLE` as the canonical public monorepo and added
   contributor, security, architecture, protocol, and validation documentation.
 - Added an independent `/privacy` policy and stable `/app` landing page, with

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,25 @@
+cff-version: 1.2.0
+message: >-
+  If you use PyBLE in research, teaching, or another published work, please
+  cite the exact archived software version you used.
+title: "PyBLE: Python over Bluetooth Low Energy"
+type: software
+authors:
+  - family-names: Vchirawongkwin
+    given-names: Viwat
+abstract: >-
+  PyBLE is a free, MIT-licensed, tablet-first MicroPython integrated
+  development environment. Its Flutter app connects to compatible boards
+  running the portable PyBLE agent over Bluetooth Low Energy through the open
+  PBLE/1 protocol, enabling code editing, file transfer, program control, and
+  console streaming without an everyday USB or Wi-Fi connection.
+keywords:
+  - Bluetooth Low Energy
+  - MicroPython
+  - physical computing
+  - embedded systems
+  - Flutter
+  - tablet IDE
+license: MIT
+repository-code: "https://github.com/PyBLE-dev/PyBLE"
+url: "https://pyble.dev"

--- a/README.md
+++ b/README.md
@@ -258,6 +258,13 @@ fail-closed unless an explicit validated release input is supplied.
 - [Validation evidence index](docs/validation/README.md)
 - [Security policy](SECURITY.md)
 
+## Citation
+
+If you use PyBLE in research, teaching, or another published work, use the
+metadata in [CITATION.cff](CITATION.cff). The app and firmware are versioned
+independently, so cite the exact archived project snapshot or component
+release you used; qualified firmware v0.6.0 is not the app version.
+
 ## Contributing
 
 Contributions are welcome, especially new validated board ports, protocol and

--- a/tests/publication/test_citation_metadata.py
+++ b/tests/publication/test_citation_metadata.py
@@ -45,6 +45,7 @@ class CitationMetadataTest(unittest.TestCase):
         self.assertNotRegex(self.citation, r"(?im)^\s*(orcid|affiliation):")
 
     def test_citation_describes_the_open_ble_first_software(self) -> None:
+        normalized = " ".join(self.citation.split())
         for wording in (
             "tablet-first MicroPython integrated development environment",
             "Bluetooth Low Energy",
@@ -53,7 +54,7 @@ class CitationMetadataTest(unittest.TestCase):
             "physical computing",
             "embedded systems",
         ):
-            self.assertIn(wording, self.citation)
+            self.assertIn(wording, normalized)
 
     def test_release_identity_is_complete_or_intentionally_project_level(
         self,
@@ -78,13 +79,22 @@ class CitationMetadataTest(unittest.TestCase):
         )
 
     def test_repository_contract_and_public_docs_expose_the_citation(self) -> None:
-        self.assertRegex(
-            self.contributor_guidelines,
-            r"(?s)Root governance files are:.{0,260}`CITATION\.cff`",
+        governance_start = self.contributor_guidelines.index(
+            "Root governance files are:"
         )
+        governance_end = self.contributor_guidelines.index(
+            "```", governance_start + len("Root governance files are:") + 4
+        )
+        governance_files = self.contributor_guidelines[
+            governance_start:governance_end
+        ]
+        normalized_readme = " ".join(self.readme.split())
+        self.assertIn("CITATION.cff", governance_files)
         self.assertIn("## Citation", self.readme)
         self.assertIn("[CITATION.cff](CITATION.cff)", self.readme)
-        self.assertIn("app and firmware are versioned independently", self.readme)
+        self.assertIn(
+            "app and firmware are versioned independently", normalized_readme
+        )
         self.assertIn("CITATION.cff", self.changelog)
 
 

--- a/tests/publication/test_citation_metadata.py
+++ b/tests/publication/test_citation_metadata.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: MIT
+# Part of PyBLE (https://pyble.dev) — see /LICENSE.
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class CitationMetadataTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.citation_path = REPO_ROOT / "CITATION.cff"
+        cls.citation = (
+            cls.citation_path.read_text(encoding="utf-8")
+            if cls.citation_path.exists()
+            else ""
+        )
+        cls.readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+        cls.changelog = (REPO_ROOT / "CHANGELOG.md").read_text(
+            encoding="utf-8"
+        )
+        cls.contributor_guidelines = (REPO_ROOT / "AGENTS.md").read_text(
+            encoding="utf-8"
+        )
+
+    def test_root_citation_file_identifies_the_project(self) -> None:
+        self.assertTrue(self.citation_path.is_file())
+        for field in (
+            "cff-version: 1.2.0",
+            'title: "PyBLE: Python over Bluetooth Low Energy"',
+            "type: software",
+            "license: MIT",
+            'repository-code: "https://github.com/PyBLE-dev/PyBLE"',
+            'url: "https://pyble.dev"',
+        ):
+            self.assertIn(field, self.citation)
+
+    def test_citation_names_only_the_evidenced_author_identity(self) -> None:
+        self.assertIn("family-names: Vchirawongkwin", self.citation)
+        self.assertIn("given-names: Viwat", self.citation)
+        self.assertNotRegex(self.citation, r"(?im)^\s*(orcid|affiliation):")
+
+    def test_citation_describes_the_open_ble_first_software(self) -> None:
+        for wording in (
+            "tablet-first MicroPython integrated development environment",
+            "Bluetooth Low Energy",
+            "PBLE/1",
+            "Flutter",
+            "physical computing",
+            "embedded systems",
+        ):
+            self.assertIn(wording, self.citation)
+
+    def test_release_identity_is_complete_or_intentionally_project_level(
+        self,
+    ) -> None:
+        has_doi = re.search(r"(?m)^doi:\s*", self.citation) is not None
+        has_version = re.search(r"(?m)^version:\s*", self.citation) is not None
+        has_release_date = (
+            re.search(r"(?m)^date-released:\s*", self.citation) is not None
+        )
+        self.assertEqual(has_doi, has_version)
+        self.assertEqual(has_doi, has_release_date)
+        if has_doi:
+            self.assertRegex(
+                self.citation,
+                r"(?m)^doi:\s*[\"']?10\.5281/zenodo\.\d+[\"']?\s*$",
+            )
+
+    def test_metadata_contains_no_placeholder_identifiers(self) -> None:
+        self.assertNotRegex(
+            self.citation,
+            r"(?i)(todo|fixme|your[-_ ]?(doi|orcid)|0000-0000-0000-0000)",
+        )
+
+    def test_repository_contract_and_public_docs_expose_the_citation(self) -> None:
+        self.assertRegex(
+            self.contributor_guidelines,
+            r"(?s)Root governance files are:.{0,260}`CITATION\.cff`",
+        )
+        self.assertIn("## Citation", self.readme)
+        self.assertIn("[CITATION.cff](CITATION.cff)", self.readme)
+        self.assertIn("app and firmware are versioned independently", self.readme)
+        self.assertIn("CITATION.cff", self.changelog)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a CFF 1.2 project citation file for PyBLE
- expose citation guidance without conflating app and firmware versions
- update the root-file governance contract and changelog
- add publication regression coverage

## Release boundary

This PR intentionally omits a version, release date, and DOI until the exact whole-project source snapshot is archived. Firmware 0.6.0 is not a version for the independently versioned app. No ORCID or institutional affiliation is invented.

## Validation

- CFF 1.2 schema validation with cffconvert 2.0.0
- BibTeX and Zenodo conversion checks
- 35 publication tests
- documentation link gate
- no-leak gate
- SPDX gate
- DCO range check