### PR TITLE
[docs] Identify citation snapshot 2026.08.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,8 +56,9 @@ its annotated tag rather than from the newer branch tip.
 
 ### Website and repository source
 
-- Added project-level `CITATION.cff` metadata for scholarly citation while
-  preserving the independently versioned app and firmware release identities.
+- Added project-level `CITATION.cff` metadata and identified whole-project
+  source snapshot `2026.08.23` for scholarly citation while preserving the
+  independently versioned app and firmware release identities.
 - Established `PyBLE-dev/PyBLE` as the canonical public monorepo and added
   contributor, security, architecture, protocol, and validation documentation.
 - Added an independent `/privacy` policy and stable `/app` landing page, with

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,6 +4,8 @@ message: >-
   cite the exact archived software version you used.
 title: "PyBLE: Python over Bluetooth Low Energy"
 type: software
+version: "2026.08.23"
+date-released: "2026-08-23"
 authors:
   - family-names: Vchirawongkwin
     given-names: Viwat

--- a/README.md
+++ b/README.md
@@ -265,6 +265,11 @@ metadata in [CITATION.cff](CITATION.cff). The app and firmware are versioned
 independently, so cite the exact archived project snapshot or component
 release you used; qualified firmware v0.6.0 is not the app version.
 
+The first whole-project citation snapshot is
+[2026.08.23](https://github.com/PyBLE-dev/PyBLE/releases/tag/source-2026.08.23).
+It contains app source `0.1.0+4` and records qualified firmware `0.6.0` as a
+separate component release.
+
 ## Contributing
 
 Contributions are welcome, especially new validated board ports, protocol and

--- a/tests/publication/test_citation_metadata.py
+++ b/tests/publication/test_citation_metadata.py
@@ -56,16 +56,16 @@ class CitationMetadataTest(unittest.TestCase):
         ):
             self.assertIn(wording, normalized)
 
-    def test_release_identity_is_complete_or_intentionally_project_level(
-        self,
-    ) -> None:
+    def test_release_identity_is_complete_for_the_project_snapshot(self) -> None:
         has_doi = re.search(r"(?m)^doi:\s*", self.citation) is not None
         has_version = re.search(r"(?m)^version:\s*", self.citation) is not None
         has_release_date = (
             re.search(r"(?m)^date-released:\s*", self.citation) is not None
         )
-        self.assertEqual(has_doi, has_version)
-        self.assertEqual(has_doi, has_release_date)
+        self.assertTrue(has_version)
+        self.assertEqual(has_version, has_release_date)
+        self.assertIn('version: "2026.08.23"', self.citation)
+        self.assertIn('date-released: "2026-08-23"', self.citation)
         if has_doi:
             self.assertRegex(
                 self.citation,


### PR DESCRIPTION
## Summary

- identify the first whole-project citation snapshot as 2026.08.23
- add the matching CFF release date and public release link
- preserve app 0.1.0 build 4 and qualified firmware 0.6.0 as independently versioned components
- keep the DOI optional until Zenodo mints the immutable version DOI

## Validation

- CFF 1.2 schema validation with cffconvert 2.0.0
- successful Zenodo metadata conversion with version and publication date
- 35 publication tests
- documentation link gate
- no-leak gate
- SPDX gate
- DCO range check