### PR TITLE
[docs] Publish minted Zenodo DOI metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,8 +57,10 @@ its annotated tag rather than from the newer branch tip.
 ### Website and repository source
 
 - Added project-level `CITATION.cff` metadata and identified whole-project
-  source snapshot `2026.08.23` for scholarly citation while preserving the
-  independently versioned app and firmware release identities.
+  source snapshot `source-2026.08.23` with exact Zenodo DOI
+  [`10.5281/zenodo.22064468`](https://doi.org/10.5281/zenodo.22064468) for
+  scholarly citation while preserving the independently versioned app and
+  firmware release identities.
 - Established `PyBLE-dev/PyBLE` as the canonical public monorepo and added
   contributor, security, architecture, protocol, and validation documentation.
 - Added an independent `/privacy` policy and stable `/app` landing page, with

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,8 +4,9 @@ message: >-
   cite the exact archived software version you used.
 title: "PyBLE: Python over Bluetooth Low Energy"
 type: software
-version: "2026.08.23"
+version: "source-2026.08.23"
 date-released: "2026-08-23"
+doi: "10.5281/zenodo.22064468"
 authors:
   - family-names: Vchirawongkwin
     given-names: Viwat

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ MicroPython IDE.
 
 [![CI](https://github.com/PyBLE-dev/PyBLE/actions/workflows/ci.yml/badge.svg)](https://github.com/PyBLE-dev/PyBLE/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-yellow.svg)](LICENSE)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.22064467.svg)](https://doi.org/10.5281/zenodo.22064467)
 [![Platforms](https://img.shields.io/badge/app-iPadOS%20%7C%20Android-2D5BFF.svg)](#app)
 [![Protocol](https://img.shields.io/badge/protocol-PBLE%2F1-0E7490.svg)](docs/specifications/protocol.md)
 [![Firmware](https://img.shields.io/badge/firmware-v0.6.0%20qualified-15803D.svg)](https://pyble.dev/flash)
@@ -266,9 +267,13 @@ independently, so cite the exact archived project snapshot or component
 release you used; qualified firmware v0.6.0 is not the app version.
 
 The first whole-project citation snapshot is
-[2026.08.23](https://github.com/PyBLE-dev/PyBLE/releases/tag/source-2026.08.23).
-It contains app source `0.1.0+4` and records qualified firmware `0.6.0` as a
-separate component release.
+[`source-2026.08.23`](https://github.com/PyBLE-dev/PyBLE/releases/tag/source-2026.08.23).
+Cite that exact snapshot with DOI
+[`10.5281/zenodo.22064468`](https://doi.org/10.5281/zenodo.22064468); use the
+project concept DOI
+[`10.5281/zenodo.22064467`](https://doi.org/10.5281/zenodo.22064467) to link
+all archived PyBLE versions. The snapshot contains app source `0.1.0+4` and
+records qualified firmware `0.6.0` as a separate component release.
 
 ## Contributing
 

--- a/tests/publication/test_citation_metadata.py
+++ b/tests/publication/test_citation_metadata.py
@@ -62,15 +62,13 @@ class CitationMetadataTest(unittest.TestCase):
         has_release_date = (
             re.search(r"(?m)^date-released:\s*", self.citation) is not None
         )
+        self.assertTrue(has_doi)
         self.assertTrue(has_version)
         self.assertEqual(has_version, has_release_date)
-        self.assertIn('version: "2026.08.23"', self.citation)
+        self.assertIn('version: "source-2026.08.23"', self.citation)
         self.assertIn('date-released: "2026-08-23"', self.citation)
-        if has_doi:
-            self.assertRegex(
-                self.citation,
-                r"(?m)^doi:\s*[\"']?10\.5281/zenodo\.\d+[\"']?\s*$",
-            )
+        self.assertIn('doi: "10.5281/zenodo.22064468"', self.citation)
+        self.assertNotIn("10.5281/zenodo.22064467", self.citation)
 
     def test_metadata_contains_no_placeholder_identifiers(self) -> None:
         self.assertNotRegex(
@@ -95,7 +93,14 @@ class CitationMetadataTest(unittest.TestCase):
         self.assertIn(
             "app and firmware are versioned independently", normalized_readme
         )
+        self.assertIn("https://doi.org/10.5281/zenodo.22064468", self.readme)
+        self.assertIn("https://doi.org/10.5281/zenodo.22064467", self.readme)
+        self.assertIn(
+            "https://zenodo.org/badge/DOI/10.5281/zenodo.22064467.svg",
+            self.readme,
+        )
         self.assertIn("CITATION.cff", self.changelog)
+        self.assertIn("10.5281/zenodo.22064468", self.changelog)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- add the exact snapshot DOI to CITATION.cff
- align the citation version with the immutable Zenodo record
- add the concept DOI badge for all archived PyBLE versions
- document the exact and concept DOI roles in README and CHANGELOG
- add regression coverage for both identifiers

## Minted identifiers

- Exact snapshot: https://doi.org/10.5281/zenodo.22064468
- All versions / concept: https://doi.org/10.5281/zenodo.22064467
- Zenodo record: https://zenodo.org/records/22064468
- Source release: https://github.com/PyBLE-dev/PyBLE/releases/tag/source-2026.08.23

## Validation

- CFF 1.2 schema validation with cffconvert 2.0.0
- successful BibTeX conversion containing the exact DOI
- successful Zenodo metadata conversion
- exact DOI, concept DOI, and badge resolve with HTTP 200
- 35 publication tests
- documentation link, no-leak, SPDX, and DCO gates