### PR TITLE
[build] bump fast-uri from 3.1.5 to 3.1.7 in /tools/web

### DIFF
--- a/tools/web/package-lock.json
+++ b/tools/web/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@pyble/web",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@material/web": "2.2.0",
@@ -3503,9 +3504,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## What changed

- update the indirect fast-uri lock entry from 3.1.5 to 3.1.7
- take the published upstream v3 URI/host validation security fixes
- retain npm-generated root hasInstallScript metadata for the existing postinstall script
- supersede #29 because main is rebase-only and its bot commit subject lacks the mandatory allowed prefix

## Specification and tests

- Specification: N/A — build-only transitive dependency lock update; no public PyBLE contract changes
- Tests: npm ci
- Tests: NEXT_TELEMETRY_DISABLED=1 npm run check
  - formatting, lint, type checking, dependency audit, and license check
  - 282/282 Vitest tests
  - vinext compatibility check
  - Next.js and Vinext production builds
- Additional: regenerated with the repository-pinned Node 24.2.0 and npm 11.3.0; resulting diff is byte-for-byte identical to #29

## Checklist

- [x] The change is focused and linked to an issue when appropriate.
- [x] Every commit is signed off (git commit -s).
- [x] No contract change; no specification update is required.
- [x] Build-only dependency metadata; existing automated coverage is green.
- [x] The no-leak and SPDX gates pass.
- [x] No new dependency; existing third-party records remain applicable.
- [x] No user-facing strings changed.
- [x] Upstream submodules remain pristine and pinned.
- [x] No hardware claims are made.
- [x] No non-public security-sensitive details are disclosed.